### PR TITLE
Fix unmarshaling spell ids when they are strings

### DIFF
--- a/constants/summoner_spell/summoner_spell.go
+++ b/constants/summoner_spell/summoner_spell.go
@@ -3,6 +3,7 @@ package summoner_spell
 import (
 	"fmt"
 	"io"
+	"encoding/json"
 )
 
 type ID int
@@ -81,6 +82,24 @@ func (s ID) String() String {
 
 func (s String) ID() ID {
 	return stringToIDMap[s]
+}
+
+func (s *ID) UnmarshalJSON(data []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	switch id := v.(type) {
+	case float64:
+		*s = ID(id)
+	case string:
+		*s = String(id).ID()
+	default:
+		return fmt.Errorf("invalid spell id: %v", id)
+	}
+
+	return nil
 }
 
 // UnmarshalGQL implements the graphql.Unmarshaler interface

--- a/constants/summoner_spell/summoner_spell_test.go
+++ b/constants/summoner_spell/summoner_spell_test.go
@@ -1,0 +1,39 @@
+package summoner_spell
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type TestStruct struct {
+	ID ID `json:"id"`
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	expectedResult := TestStruct{ID: ID(4)}
+
+	validIntId := []byte(`{"id": 4}`)
+	validStringId := []byte(`{"id": "SummonerFlash"}`)
+
+	// Test case 1: Should correctly unmarshal number id
+	var id TestStruct
+	err := json.Unmarshal(validIntId, &id)
+	if err != nil {
+		t.Errorf("Expected no error. Error: %v", err)
+	}
+
+	if expectedResult != id {
+		t.Errorf("Expected: %v - Got: %v", expectedResult, id)
+	}
+
+	// Test case 2: Should correctly unmarshal string id
+	var id2 TestStruct
+	err = json.Unmarshal(validStringId, &id2)
+	if err != nil {
+		t.Errorf("Expected no error. Error: %v", err)
+	}
+
+	if expectedResult != id2 {
+		t.Errorf("Expected: %v - Got: %v", expectedResult, id)
+	}
+}


### PR DESCRIPTION
When using GetSummonerSpells in the staticdata it results in a panic because the spell endpoint ([Here](https://ddragon.leagueoflegends.com/cdn/14.6.1/data/en_US/summoner.json)) returns ids as a string and not an int like the match endpoint.

The error
```
2024/03/24 16:26:16 http: panic serving 127.0.0.1:58436: json: cannot unmarshal string into Go struct field SummonerSpell.data.id of type summoner_spell.ID
```
I made a simple fix by just adding some unmarshal logic to convert strings and ints correctly to an ID. However the ddragon endpoint i linked above has the int id specified as a "key" instead of an "id" so im not sure if this is really an ideal fix.
